### PR TITLE
Separating dev workflow from releases

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-BRANCH_RELEASE="main"
-BRANCH_WORKING="main"
+BRANCH_RELEASE="releases"
+BRANCH_WORKING="dev"
 REMOTE="origin"
-PROJECT_URL=""
+PROJECT_URL="https://github.com/EdgeLimits/release.sh/issues"
 REPOSITORY_URL="https://github.com/EdgeLimits/release.sh"
 CHANGELOG_FILE="CHANGELOG.md"
 CHANGELOG_COMMIT_MESSAGE="docs: update CHANGELOG.md"
@@ -172,7 +172,7 @@ generate_changelog() {
     local log="$3"
 
     section=$(echo "$log" | grep "$keyword(\|$keyword:" |
-      sed -E -e "s|#([0-9]+)|$(if [[ -n "$PROJECT_URL" ]]; then echo "[#\1](${PROJECT_URL}\1)"; else echo "#\1"; fi)|g" \
+      sed -E -e "s|#([0-9]+)|$(if [[ -n "$PROJECT_URL" ]]; then echo "[#\1](${PROJECT_URL}/\1)"; else echo "#\1"; fi)|g" \
         -e "s|^([a-f0-9]{7,40}) (.+)$|* \2 [\1](${REPOSITORY_URL}/commit/\1)|")
     if [[ -n "$section" ]]; then
       output+=$(printf "### %s\n\n" "$title")


### PR DESCRIPTION
Resolves: #1 

**releases** branch will include only the code changes associated with a release version (tag)
Allowing to continue development on the **dev** branch.